### PR TITLE
style the toc-container scrollbar on webkit

### DIFF
--- a/assets/css/_docs.scss
+++ b/assets/css/_docs.scss
@@ -181,6 +181,8 @@ html.docs {
   }
 
   .toc-container {
+    @include minimal-scrollbar();
+
     background-color: $foreground;
     display: none;
     flex: none;

--- a/assets/css/_mixins.scss
+++ b/assets/css/_mixins.scss
@@ -1,0 +1,19 @@
+@mixin minimal-scrollbar() {
+  &::-webkit-scrollbar {
+    -webkit-appearance: none;
+  }
+
+  &::-webkit-scrollbar:vertical {
+    width: 11px;
+  }
+
+  &::-webkit-scrollbar:horizontal {
+    height: 11px;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    border-radius: 8px;
+    border: 2px solid white; // should match background, can't be transparent
+    background-color: rgba(0, 0, 0, .33);
+  }
+}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -7,6 +7,7 @@
 @import url("{{ href }}");
 {% endfor %}
 
+@import "mixins";
 @import "default";
 @import "home";
 @import "custom-builds";


### PR DESCRIPTION
I let you decide if you want to apply `minimal-scrollbar()` to `.doc-container` as well. I did not because the scrollbar ends up being very tiny (and I'm on 1440p, so I can't even imagine 1080p).