### PR TITLE
improve irregular logo spacing on mobile

### DIFF
--- a/assets/css/_media-queries.scss
+++ b/assets/css/_media-queries.scss
@@ -30,6 +30,7 @@
 
     .logo {
       padding: 0 0.6rem 0 0;
+      margin: 0 0.6rem 0 0;
     }
   }
 }


### PR DESCRIPTION
This does 2 things:

1. Give the same whitespace before and after the gray border between the logo and the title, in the header.
2. Gives enough room for the menu to fit on an iPhone 5/SE.