### PR TITLE
make it possible to vertically scroll through long method names

### DIFF
--- a/assets/css/_docs.scss
+++ b/assets/css/_docs.scss
@@ -73,6 +73,7 @@ html.docs {
       font-weight: 700;
       margin: 0 -999rem;
       padding: 3.2rem 999rem;
+      overflow-y: hidden;
 
       a {
         border-bottom: 0;


### PR DESCRIPTION
This plays a little weird on a very small screen on desktop. The scrollbar is very very wide (beyond the viewport). It seems to be because of the margin and padding set to -999 and 999rem. What was @zackhall intention with this?

```
h3 {
    ...
    margin: 0 -999rem;
    padding: 3.2rem 999rem;
    ...
}
```

https://github.com/lodash/lodash.com/blob/master/assets/css/_docs.scss#L74-L75