### PR TITLE
remove some padding on doc container on mobile

### DIFF
--- a/assets/css/_media-queries.scss
+++ b/assets/css/_media-queries.scss
@@ -32,6 +32,11 @@
       padding: 0 0.6rem 0 0;
       margin: 0 0.6rem 0 0;
     }
+
+    .doc-container {
+      padding-left: 3.2rem;
+      padding-right: 3.2rem;
+    }
   }
 }
 


### PR DESCRIPTION
On small phones like the iPhone 5/SE, there was too much horizontal padding, making lines a bit short for reading.

<table>
<tr>
<th>
Before
</th>
<th>
After
</th>
</tr>
<tr>
<td>
<img src="https://cloud.githubusercontent.com/assets/3461986/19097010/31f8ae36-8a6f-11e6-9c85-34ed089f2945.png" width="100%">
</td>
<td>
<img src="https://cloud.githubusercontent.com/assets/3461986/19097014/35727dd0-8a6f-11e6-989b-96ba6f70da4d.png" width="100%">
</td>
</tr>
</table>