### PR TITLE
Leverage flexbox to improve search items alignments

### DIFF
--- a/assets/css/_docs.scss
+++ b/assets/css/_docs.scss
@@ -166,29 +166,45 @@ html.docs {
   }
 
   .search {
+    display: flex;
+    align-items: center;
     position: relative;
     width: 100%;
+    padding: 10px 0 10px 7px;
 
     input {
       border: none;
-      border-bottom: 2px solid $defaultLiteColor;
       font-size: 1.4rem;
-      padding: 10px 0;
-      text-indent: 30px;
       width: 100%;
+      margin-left: 10px;
+      appearance: none;
+      -webkit-appearance: none;
+      flex: 1;
+
+      &::-webkit-search-decoration {
+        -webkit-appearance: none;
+      }
 
       &:focus {
-        border-bottom-color: $defaultNearColor;
         outline: none;
+
+        + .search-focus-marker {
+          border-color: $defaultNearColor;
+        }
       }
     }
 
     .fa-search {
       color: #979797;
       font-size: 1.5rem;
-      left: 7px;
+    }
+
+    .search-focus-marker {
       position: absolute;
-      top: 9px;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      border: 1px solid $defaultLiteColor;
     }
   }
 

--- a/assets/js/docs.js
+++ b/assets/js/docs.js
@@ -320,6 +320,12 @@
               'onChange': this.onChangeSearch,
               'ref': this.onRefSearch
             }
+          ),
+          React.createElement(
+            'div',
+            {
+              'className': 'search-focus-marker'
+            }
           )
         ),
         elements,


### PR DESCRIPTION
# Google Chrome

**Before:**

<img width="268" alt="screen shot 2016-10-30 at 10 33 10" src="https://cloud.githubusercontent.com/assets/2657709/19835598/52984486-9e8c-11e6-97c0-2d2e2eca8b99.png">

**After:** 

<img width="274" alt="screen shot 2016-10-30 at 10 33 03" src="https://cloud.githubusercontent.com/assets/2657709/19835602/61f89d22-9e8c-11e6-9fd2-5ceeb703e22a.png">

# Safari

**Before**

<img width="284" alt="screen shot 2016-10-30 at 10 34 43" src="https://cloud.githubusercontent.com/assets/2657709/19835605/7d6a99fc-9e8c-11e6-8146-1f150d3dfffe.png">

**After**

<img width="279" alt="screen shot 2016-10-30 at 10 35 09" src="https://cloud.githubusercontent.com/assets/2657709/19835609/97ea9002-9e8c-11e6-8d4f-5e35e0d57408.png">

# Firefox

**Before**

<img width="289" alt="screen shot 2016-10-30 at 10 36 11" src="https://cloud.githubusercontent.com/assets/2657709/19835622/bcd26fa2-9e8c-11e6-9053-52a838810de1.png">

**After**

<img width="284" alt="screen shot 2016-10-30 at 10 36 58" src="https://cloud.githubusercontent.com/assets/2657709/19835624/cfc5069c-9e8c-11e6-856f-21724a849367.png">

