### PR TITLE
Remove Courier New from font-family

### DIFF
--- a/assets/css/_default.scss
+++ b/assets/css/_default.scss
@@ -168,7 +168,7 @@ header {
 }
 
 pre, code {
-  font-family: Consolas, "Courier New", monospace;
+  font-family: Consolas, monospace;
 }
 
 section {


### PR DESCRIPTION
Before with Courier New

![image](https://cloud.githubusercontent.com/assets/3112509/20385838/10bb3a8a-acdf-11e6-935c-de5374a06422.png)

After with default monospace:

![image](https://cloud.githubusercontent.com/assets/3112509/20385854/250caed8-acdf-11e6-9124-41b8c73f5a6b.png)

I don't have Consolas installed on my Ubuntu 16.04. So the code looks extremely bad with Courier New font-family. The default monospace looks better.