### PR TITLE
Add location.hash to version change

### DIFF
--- a/assets/js/docs.js
+++ b/assets/js/docs.js
@@ -345,10 +345,11 @@
   // Change the documentation URL.
   versionSelect.addEventListener('change', function(event) {
     var value = event.target.value;
+    var hash = location.hash;
     if (value) {
       location.href = value == '1.3.1'
         ? '{{ site.links.docs_v1 }}'
-        : '/docs/' + value;
+        : '/docs/' + value + hash;
     }
   });
 


### PR DESCRIPTION
While migrating a project from lodash v3 to v4, I wanted to confirm that method signatures hadn't changed. I had to search for the method each time I switched between versions.

I thought it would be helpful to jump to the current chosen method while switching between versions, instead of having to find the method each time.