### PR TITLE
The ad in the toc in the docs doesn't stay position fixed

### DIFF
--- a/assets/css/_carbon.scss
+++ b/assets/css/_carbon.scss
@@ -10,6 +10,7 @@
   overflow: hidden;
   padding: 2rem 0;
   position: fixed;
+  z-index: 2;
 
   a {
     border-bottom: 0;

--- a/assets/js/docs.js
+++ b/assets/js/docs.js
@@ -35,7 +35,7 @@
       var script = document.createElement('script');
       script.id = '{{ site.carbon_ads.id }}';
       script.src = '{{ site.carbon_ads.href }}';
-      toc.insertBefore(script, toc.firstChild);
+      toc.insertBefore(script);
       carbonated = true;
     }
   }


### PR DESCRIPTION
I'm seeing the add scroll with the content instead of staying fixed.

![image](https://cloud.githubusercontent.com/assets/1710840/20975462/dd5991c0-bc9f-11e6-8f21-c36f2788c7e0.png)

The problem occurs on:
* chrome: 54.0.2840.99 m
* Window 10 x64
* With and without adblock
* In incognito mode and without (no extensions are loaded in incognito)

It doesn't occur on:
* Firefox
* Edge (though it jitters while scrolling. This should also be fixed with this PR)

I propose we move it outside the toc scrollable to make sure it stays fixed.
