### PR TITLE
Set flex-shrink on header to 0. fixes #126

### DIFF
--- a/assets/css/_default.scss
+++ b/assets/css/_default.scss
@@ -103,6 +103,7 @@ header {
   padding: 0.8rem 0;
   position: relative;
   z-index: 2;
+  flex-shrink: 0;
 
   .container {
     align-items: center;


### PR DESCRIPTION
Header in Safari 9 seems to be squished to 0 height without setting flex-shrink to 0