### PR TITLE
Only fade methods actually beginning with _.

### DIFF
--- a/assets/js/docs.js
+++ b/assets/js/docs.js
@@ -293,17 +293,26 @@
                     'onClick': _this.onClickMenuItem,
                     'ref': isLastEntry ? _this.onRefMenuItem : undefined
                   },
-                  React.createElement(
-                    'code',
-                    null,
-                    React.createElement(
-                      'span',
-                      {
-                        className: 'subtle-punctuation'
-                      },
-                      '_.'
-                    ),
-                    entry.name.slice(2)
+                  React.createElement.apply(
+                    this,
+                    [
+                      'code',
+                      null,
+                    ]
+                    .concat(
+                      entry.name.match(/^_\./)
+                      ? [
+                        React.createElement(
+                          'span',
+                          {
+                            className: 'subtle-punctuation'
+                          },
+                          '_.'
+                        ),
+                        entry.name.slice(2)
+                      ]
+                      : entry.name
+                    )
                   )
                 )
               )


### PR DESCRIPTION
The React script faded the first two characters of a method no matter what. Added a regex match to verify the menu item's actually beginning with `_.`