### PR TITLE
CSP: Omit https:// from source expressions

### DIFF
--- a/_headers
+++ b/_headers
@@ -7,58 +7,58 @@ csp:
     "'self'",
     'data:',
     'ms-appx-web:',
-    'https://ghbtns.com',
-    'https://runkit.com',
-    'https://platform.twitter.com'
+    'ghbtns.com',
+    'runkit.com',
+    'platform.twitter.com'
   ]
   connect-src: [
-    'https://lodash.report-uri.io'
+    'lodash.report-uri.io'
   ]
   img-src: [
     "'self'",
     'data:',
-    'https://*.2mdn.net',
-    'https://*.adsafeprotected.com',
-    'https://ad.atdmt.com',
-    'https://*.buysellads.com',
-    'https://*.c3tag.com',
-    'https://*.convertro.com',
-    'https://ad.doubleclick.net',
-    'https://www.google-analytics.com',
-    'https://www.launchbit.com',
-    'https://launchbit.com',
-    'https://assets.servedby-buysellads.com',
-    'https://*.serving-sys.com'
+    '*.2mdn.net',
+    '*.adsafeprotected.com',
+    'ad.atdmt.com',
+    '*.buysellads.com',
+    '*.c3tag.com',
+    '*.convertro.com',
+    'ad.doubleclick.net',
+    'www.google-analytics.com',
+    'www.launchbit.com',
+    'launchbit.com',
+    'assets.servedby-buysellads.com',
+    '*.serving-sys.com'
   ]
   font-src: [
     "'self'",
     'data:',
-    'https://fonts.gstatic.com',
-    'https://cdn.jsdelivr.net'
+    'fonts.gstatic.com',
+    'cdn.jsdelivr.net'
   ]
   frame-src: [
     "'self'",
     'data:',
     'ms-appx-web:',
-    'https://ghbtns.com',
-    'https://runkit.com',
-    'https://platform.twitter.com'
+    'ghbtns.com',
+    'runkit.com',
+    'platform.twitter.com'
   ]
   manifest-src: [
     "'self'"
   ]
   script-src: [
     "'self'",
-    'https://*.carbonads.com',
-    'https://srv.carbonads.net',
-    'https://adn.fusionads.net',
-    'https://www.google-analytics.com',
-    'https://cdn.jsdelivr.net',
-    'https://embed.runkit.com'
+    '*.carbonads.com',
+    'srv.carbonads.net',
+    'adn.fusionads.net',
+    'www.google-analytics.com',
+    'cdn.jsdelivr.net',
+    'embed.runkit.com'
   ]
   style-src: [
     "'self'",
-    'https://cdn.jsdelivr.net'
+    'cdn.jsdelivr.net'
   ]
 hints:
   all: [


### PR DESCRIPTION
This doesn't implicitly whitelist http when the page is served via https, as explained by Scott Helme in
https://scotthelme.co.uk/optimising-twitters-csp-header/

See also https://www.w3.org/TR/CSP2/#match-source-expression, specifically:

> 4.5. If the source expression does **not** have a scheme, return _does not match_ if any of the following are true:
>   1. the scheme of the protected resource’s URL is a case insensitive match for HTTP, and url-scheme is **not** a case insensitive match for either HTTP or HTTPS
>   2. the scheme of the protected resource’s URL is not a case insensitive match for HTTP, and url-scheme is **not** a case insensitive match for the scheme of the protected resource’s URL.
