### PR TITLE
Fix some source links in 4.17.10.html

### DIFF
--- a/docs/4.17.10.html
+++ b/docs/4.17.10.html
@@ -4968,7 +4968,7 @@ values of <code>object</code>.
 <h2><code>&#x201C;Seq&#x201D; Methods</code></h2>
 <div>
 <h3 id="lodash"><a href="#lodash" class="fa fa-link"></a><code>_(value)</code></h3>
-[source](https://github.com/lodash/lodash/blob/4.17.10/lodash.js#L1662)
+<p><a href="https://github.com/lodash/lodash/blob/4.17.10/lodash.js#L1662">source</a></p>
 <p>Creates a <code>lodash</code> object which wraps <code>value</code> to enable implicit method
 chain sequences. Methods that operate on and return arrays, collections,
 and functions can be chained together. Methods that retrieve a single value
@@ -5080,7 +5080,7 @@ The wrapper methods that are <strong>not</strong> chainable by default are:<br>
 </div>
 <div>
 <h3 id="chain"><a href="#chain" class="fa fa-link"></a><code>_.chain(value)</code></h3>
-[source](https://github.com/lodash/lodash/blob/4.17.10/lodash.js#L8737)
+<p><a href="https://github.com/lodash/lodash/blob/4.17.10/lodash.js#L8737">source</a></p>
 <p>Creates a <code>lodash</code> wrapper instance that wraps <code>value</code> with explicit method
 chain sequences enabled. The result of such sequences must be unwrapped
 with <code>_#value</code>.</p>
@@ -5098,7 +5098,7 @@ with <code>_#value</code>.</p>
 </div>
 <div>
 <h3 id="tap"><a href="#tap" class="fa fa-link"></a><code>_.tap(value, interceptor)</code></h3>
-[source](https://github.com/lodash/lodash/blob/4.17.10/lodash.js#L8766)
+<p><a href="https://github.com/lodash/lodash/blob/4.17.10/lodash.js#L8766">source</a></p>
 <p>This method invokes <code>interceptor</code> and returns <code>value</code>. The interceptor
 is invoked with one argument; <em>(value)</em>. The purpose of this method is to
 &quot;tap into&quot; a method chain sequence in order to modify intermediate results.</p>
@@ -5117,7 +5117,7 @@ is invoked with one argument; <em>(value)</em>. The purpose of this method is to
 </div>
 <div>
 <h3 id="thru"><a href="#thru" class="fa fa-link"></a><code>_.thru(value, interceptor)</code></h3>
-[source](https://github.com/lodash/lodash/blob/4.17.10/lodash.js#L8794)
+<p><a href="https://github.com/lodash/lodash/blob/4.17.10/lodash.js#L8794">source</a></p>
 <p>This method is like <a href="#tap"><code>_.tap</code></a> except that it returns the result of <code>interceptor</code>.
 The purpose of this method is to &quot;pass thru&quot; values replacing intermediate
 results in a method chain sequence.</p>
@@ -5136,7 +5136,7 @@ results in a method chain sequence.</p>
 </div>
 <div>
 <h3 id="prototype-Symbol-iterator"><a href="#prototype-Symbol-iterator" class="fa fa-link"></a><code>_.prototype[Symbol.iterator]()</code></h3>
-[source](https://github.com/lodash/lodash/blob/4.17.10/lodash.js#L8949)
+<p><a href="https://github.com/lodash/lodash/blob/4.17.10/lodash.js#L8949">source</a></p>
 <p>Enables the wrapper to be iterable.</p>
 <h4>Since</h4>
 <p>4.0.0</p>
@@ -5148,7 +5148,7 @@ results in a method chain sequence.</p>
 </div>
 <div>
 <h3 id="prototype-at"><a href="#prototype-at" class="fa fa-link"></a><code>_.prototype.at([paths])</code></h3>
-[source](https://github.com/lodash/lodash/blob/4.17.10/lodash.js#L8814)
+<p><a href="https://github.com/lodash/lodash/blob/4.17.10/lodash.js#L8814">source</a></p>
 <p>This method is the wrapper version of <a href="#at"><code>_.at</code></a>.</p>
 <h4>Since</h4>
 <p>1.0.0</p>
@@ -5164,7 +5164,7 @@ results in a method chain sequence.</p>
 </div>
 <div>
 <h3 id="prototype-chain"><a href="#prototype-chain" class="fa fa-link"></a><code>_.prototype.chain()</code></h3>
-[source](https://github.com/lodash/lodash/blob/4.17.10/lodash.js#L8865)
+<p><a href="https://github.com/lodash/lodash/blob/4.17.10/lodash.js#L8865">source</a></p>
 <p>Creates a <code>lodash</code> wrapper instance with explicit method chain sequences enabled.</p>
 <h4>Since</h4>
 <p>0.1.0</p>
@@ -5176,7 +5176,7 @@ results in a method chain sequence.</p>
 </div>
 <div>
 <h3 id="prototype-commit"><a href="#prototype-commit" class="fa fa-link"></a><code>_.prototype.commit()</code></h3>
-[source](https://github.com/lodash/lodash/blob/4.17.10/lodash.js#L8895)
+<p><a href="https://github.com/lodash/lodash/blob/4.17.10/lodash.js#L8895">source</a></p>
 <p>Executes the chain sequence and returns the wrapped result.</p>
 <h4>Since</h4>
 <p>3.2.0</p>
@@ -5188,7 +5188,7 @@ results in a method chain sequence.</p>
 </div>
 <div>
 <h3 id="prototype-next"><a href="#prototype-next" class="fa fa-link"></a><code>_.prototype.next()</code></h3>
-[source](https://github.com/lodash/lodash/blob/4.17.10/lodash.js#L8921)
+<p><a href="https://github.com/lodash/lodash/blob/4.17.10/lodash.js#L8921">source</a></p>
 <p>Gets the next value on a wrapped object following the
 <a href="https://mdn.io/iteration_protocols#iterator">iterator protocol</a>.</p>
 <h4>Since</h4>
@@ -5201,7 +5201,7 @@ results in a method chain sequence.</p>
 </div>
 <div>
 <h3 id="prototype-plant"><a href="#prototype-plant" class="fa fa-link"></a><code>_.prototype.plant(value)</code></h3>
-[source](https://github.com/lodash/lodash/blob/4.17.10/lodash.js#L8977)
+<p><a href="https://github.com/lodash/lodash/blob/4.17.10/lodash.js#L8977">source</a></p>
 <p>Creates a clone of the chain sequence planting <code>value</code> as the wrapped value.</p>
 <h4>Since</h4>
 <p>3.2.0</p>
@@ -5217,7 +5217,7 @@ results in a method chain sequence.</p>
 </div>
 <div>
 <h3 id="prototype-reverse"><a href="#prototype-reverse" class="fa fa-link"></a><code>_.prototype.reverse()</code></h3>
-[source](https://github.com/lodash/lodash/blob/4.17.10/lodash.js#L9017)
+<p><a href="https://github.com/lodash/lodash/blob/4.17.10/lodash.js#L9017">source</a></p>
 <p>This method is the wrapper version of <a href="#reverse"><code>_.reverse</code></a>.
 <br>
 <br>
@@ -5232,7 +5232,7 @@ results in a method chain sequence.</p>
 </div>
 <div>
 <h3 id="prototype-value"><a href="#prototype-value" class="fa fa-link"></a><code>_.prototype.value()</code></h3>
-[source](https://github.com/lodash/lodash/blob/4.17.10/lodash.js#L9049)
+<p><a href="https://github.com/lodash/lodash/blob/4.17.10/lodash.js#L9049">source</a></p>
 <p>Executes the chain sequence to resolve the unwrapped value.</p>
 <h4>Since</h4>
 <p>0.1.0</p>
@@ -6429,7 +6429,7 @@ each invocation. The iteratee is invoked with one argument; <em>(index)</em>.</p
 <h2><code>Properties</code></h2>
 <div>
 <h3 id="VERSION"><a href="#VERSION" class="fa fa-link"></a><a href="#VERSION"><code>_.VERSION</code></a></h3>
-[source](https://github.com/lodash/lodash/blob/4.17.10/lodash.js#L16855)
+<p><a href="https://github.com/lodash/lodash/blob/4.17.10/lodash.js#L16855">source</a></p>
 <p>(string): The semantic version number.</p>
 
 </div>
@@ -6443,31 +6443,31 @@ following template settings to use alternative delimiters.</p>
 </div>
 <div>
 <h3 id="templateSettings-escape"><a href="#templateSettings-escape" class="fa fa-link"></a><code>_.templateSettings.escape</code></h3>
-[source](https://github.com/lodash/lodash/blob/4.17.10/lodash.js#L1739)
+<p><a href="https://github.com/lodash/lodash/blob/4.17.10/lodash.js#L1739">source</a></p>
 <p>(RegExp): Used to detect <code>data</code> property values to be HTML-escaped.</p>
 
 </div>
 <div>
 <h3 id="templateSettings-evaluate"><a href="#templateSettings-evaluate" class="fa fa-link"></a><code>_.templateSettings.evaluate</code></h3>
-[source](https://github.com/lodash/lodash/blob/4.17.10/lodash.js#L1747)
+<p><a href="https://github.com/lodash/lodash/blob/4.17.10/lodash.js#L1747">source</a></p>
 <p>(RegExp): Used to detect code to be evaluated.</p>
 
 </div>
 <div>
 <h3 id="templateSettings-imports"><a href="#templateSettings-imports" class="fa fa-link"></a><code>_.templateSettings.imports</code></h3>
-[source](https://github.com/lodash/lodash/blob/4.17.10/lodash.js#L1771)
+<p><a href="https://github.com/lodash/lodash/blob/4.17.10/lodash.js#L1771">source</a></p>
 <p>(Object): Used to import variables into the compiled template.</p>
 
 </div>
 <div>
 <h3 id="templateSettings-interpolate"><a href="#templateSettings-interpolate" class="fa fa-link"></a><code>_.templateSettings.interpolate</code></h3>
-[source](https://github.com/lodash/lodash/blob/4.17.10/lodash.js#L1755)
+<p><a href="https://github.com/lodash/lodash/blob/4.17.10/lodash.js#L1755">source</a></p>
 <p>(RegExp): Used to detect <code>data</code> property values to inject.</p>
 
 </div>
 <div>
 <h3 id="templateSettings-variable"><a href="#templateSettings-variable" class="fa fa-link"></a><code>_.templateSettings.variable</code></h3>
-[source](https://github.com/lodash/lodash/blob/4.17.10/lodash.js#L1763)
+<p><a href="https://github.com/lodash/lodash/blob/4.17.10/lodash.js#L1763">source</a></p>
 <p>(string): Used to reference the data object in the template text.</p>
 
 </div>
@@ -6476,7 +6476,7 @@ following template settings to use alternative delimiters.</p>
 <h2><code>Methods</code></h2>
 <div>
 <h3 id="templateSettings-imports-_"><a href="#templateSettings-imports-_" class="fa fa-link"></a><code>_.templateSettings.imports._</code></h3>
-[source](https://github.com/lodash/lodash/blob/4.17.10/lodash.js#L1779)
+<p><a href="https://github.com/lodash/lodash/blob/4.17.10/lodash.js#L1779">source</a></p>
 <p>A reference to the <code>lodash</code> function.</p>
 
 </div>


### PR DESCRIPTION
Several source links seems to have a Markdown-like format:
`[source](https://github.com/lodash/lodash/blob/4.17.10/lodash.js#L1779)`
and are shown as is on the website: https://lodash.com/docs/4.17.10#prototype-next

This PR reformat them in HTML:
`<p><a href="https://github.com/lodash/lodash/blob/4.17.10/lodash.js#L1662">source</a></p>`