### PR TITLE
Added collapsible-behaviour to docs title

### DIFF
--- a/assets/css/_docs.scss
+++ b/assets/css/_docs.scss
@@ -279,5 +279,10 @@ html.docs {
     .subtle-punctuation {
       opacity: 0.4;
     }
+
+    .collapsible-title {
+      cursor: pointer;
+      user-select: none;
+    }
   }
 }

--- a/assets/js/docs.js
+++ b/assets/js/docs.js
@@ -268,7 +268,11 @@
           },
           React.createElement(
             'h2',
-            null,
+            {
+              'className': 'collapsible-title',
+              'onClick': expanderClick,
+              'onKeyPress': expanderClick
+            },
             React.createElement(
               'i',
               {


### PR DESCRIPTION
I just found this ~issue~ enhancement (#165) was still open.

The code just adds a css class to every doc title when rendering it and adds the `expanderClick` on `onClick` event.