### PR TITLE
Fix source link headings not displaying

### DIFF
--- a/docs/4.17.10.html
+++ b/docs/4.17.10.html
@@ -6428,13 +6428,13 @@ each invocation. The iteratee is invoked with one argument; <em>(index)</em>.</p
 <div>
 <h2><code>Properties</code></h2>
 <div>
-<h3 id="VERSION"><a href="#VERSION" class="fa fa-link"></a><a href="#VERSION"><code>_.VERSION</code></a></h3>
+<h3 id="VERSION"><a href="#VERSION" class="fa fa-link"></a><code>_.VERSION</code></h3>
 <p><a href="https://github.com/lodash/lodash/blob/4.17.10/lodash.js#L16855">source</a></p>
 <p>(string): The semantic version number.</p>
 
 </div>
 <div>
-<h3 id="templateSettings"><a href="#templateSettings" class="fa fa-link"></a><a href="#templateSettings"><code>_.templateSettings</code></a></h3>
+<h3 id="templateSettings"><a href="#templateSettings" class="fa fa-link"></a><code>_.templateSettings</code></h3>
 <p><a href="https://github.com/lodash/lodash/blob/4.17.10/lodash.js#L1731">source</a> <a href="https://www.npmjs.com/package/lodash.templatesettings">npm package</a></p>
 <p>(Object): By default, the template delimiters used by lodash are like those in
 embedded Ruby <em>(ERB)</em> as well as ES2015 template strings. Change the


### PR DESCRIPTION
As seen on [the website](https://lodash.com/docs/4.17.10#VERSION), links for `_.VERSION` and `_.templateSettings` are not being displayed unless hovered over.

This PR removes additional anchor tags around both headings so they display like other source headings.