### PR TITLE
Removes input border radius on Safari mobile

### DIFF
--- a/assets/css/_docs.scss
+++ b/assets/css/_docs.scss
@@ -172,9 +172,10 @@ html.docs {
     width: 100%;
 
     input {
-      appearance: none;
+      -webkit-appearance: none;
       border: none;
       border-bottom: 2px solid $defaultLiteColor;
+      border-radius: 0;
       font-size: 1.4rem;
       padding: 0 0 10px 0;
       text-indent: 30px;

--- a/assets/css/_docs.scss
+++ b/assets/css/_docs.scss
@@ -172,7 +172,7 @@ html.docs {
     width: 100%;
 
     input {
-      -webkit-appearance: none;
+      appearance: none;
       border: none;
       border-bottom: 2px solid $defaultLiteColor;
       border-radius: 0;


### PR DESCRIPTION
Noticed that ya'll were getting a weird border radius happening on Safari mobile, so I thought I'd fix it for ya. Thanks for the project!

![image-1](https://user-images.githubusercontent.com/11202081/46449905-4e962880-c743-11e8-9386-784ec2eb034e.jpeg)
