### PR TITLE
fix: remove unnecessary wrap on  function name

### DIFF
--- a/docs/4.17.11.html
+++ b/docs/4.17.11.html
@@ -6428,13 +6428,13 @@ each invocation. The iteratee is invoked with one argument; <em>(index)</em>.</p
 <div>
 <h2><code>Properties</code></h2>
 <div>
-<h3 id="VERSION"><a href="#VERSION" class="fa fa-link"></a><a href="#VERSION"><code>_.VERSION</code></a></h3>
+<h3 id="VERSION"><a href="#VERSION" class="fa fa-link"></a><code>_.VERSION</code></h3>
 [source](https://github.com/lodash/lodash/blob/4.17.11/lodash.js#L16857)
 <p>(string): The semantic version number.</p>
 
 </div>
 <div>
-<h3 id="templateSettings"><a href="#templateSettings" class="fa fa-link"></a><a href="#templateSettings"><code>_.templateSettings</code></a></h3>
+<h3 id="templateSettings"><a href="#templateSettings" class="fa fa-link"></a><code>_.templateSettings</code></h3>
 <p><a href="https://github.com/lodash/lodash/blob/4.17.11/lodash.js#L1717">source</a> <a href="https://www.npmjs.com/package/lodash.templatesettings">npm package</a></p>
 <p>(Object): By default, the template delimiters used by lodash are like those in
 embedded Ruby <em>(ERB)</em> as well as ES2015 template strings. Change the


### PR DESCRIPTION
this made the function name hidden by default and visible only on hover, like the anchor icon