### PR TITLE
Guard iframe manipulation on RunKit embed to prepare for new version.

### DIFF
--- a/assets/js/docs.js
+++ b/assets/js/docs.js
@@ -443,9 +443,11 @@
             'source': source,
             'theme': 'atom-light-syntax',
             'onLoad': function(notebook) {
-              var iframe = parent.lastElementChild
-              iframe.style.cssText = 'height:' + iframe.style.height
-              iframe.classList.add('repl')
+              if (!RunKit.version) {
+                var iframe = parent.lastElementChild
+                iframe.style.cssText = 'height:' + iframe.style.height
+                iframe.classList.add('repl')
+              }
               notebook.evaluate()
             }
           })


### PR DESCRIPTION
We'll be shipping a major update to embeds that significantly improves performance, but unfortunately it will result in the layout being off on the lodash page due to its direct manipulation of RunKit's iframe. The good news is that the new version will behave the way it's currently changed to behave on lodash.com by default. This change just puts an if guard around the code in order to have the transition be smooth, after wee go live next week it can bee removed or other changes can be made too (there will be some new features you might be interested in). For now though, this should be a no-op currently and properly prepare the page for the update. Please do let me know if you have any questions or concerns.
