### PR TITLE
[Docs] add js-extra link to complementary-tools section

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,6 +75,7 @@ layout: default
   <h2>Complementary Tools</h2>
   <ul class="chevron">
     <li><a href="https://github.com/smartprocure/futil-js">futil-js</a> is a set of functional utilities designed to complement lodash</li>
+    <li><a href="https://github.com/alexandre-lelain/js-extra">js-extra</a>: a small collection of specific functions to complement lodash. Less than 1kb gzipped and tree-shakeable.</li>
   </ul>
 </section>
 


### PR DESCRIPTION
Hello!

First of all, many thanks to the contributor of Lodash, which is a library I use on a daily basis.

# What this PR does

It adds a link to [js-extra](https://js-extra.netlify.com) in the `Complementary tools` section of the main page. It is an open source library that aims to complement lodash by providing a set of few specific functions we often duplicate across applications.

I feel like it solves quite recurrent problems, that is why I'm suggesting to add it. If you think it is not suitable enough, I would totally understand.