### PR TITLE
frame-src overrides child-src if present.

### DIFF
--- a/_headers
+++ b/_headers
@@ -46,6 +46,8 @@ csp:
     'ms-appx-web:',
     'ghbtns.com',
     'runkit.com',
+    '*.runkit-embed.com',
+    'runkit-embed.com',
     'platform.twitter.com'
   ]
   manifest-src: [


### PR DESCRIPTION
Unfortunately I didn't realize that while child-src normally applies to iframes, it does not when frame-src is *also* present. This adds it there too.

Apologies for the separate commits.