### PR TITLE
Remove Google Analytics

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -86,13 +86,6 @@ carbon_ads:
   href: https://cdn.carbonads.com/carbon.js?serve=CKYIEK37&placement=lodashcom
   id: _carbonads_js
 
-google_analytics:
-  href: https://www.google-analytics.com/analytics.js
-  commands: [['create', 'UA-ACCOUNT-ID', 'auto'], ['require', 'linkid'], ['send', 'pageview']]
-  accounts:
-    lodash.com: 'UA-6065217-64'
-    lodash.dev: 'UA-134340230-1'
-
 exclude:
   - node_modules
   - Gemfile

--- a/assets/js/boot.js
+++ b/assets/js/boot.js
@@ -47,21 +47,6 @@
     iframe.src = '/appcache.html'
     document.body.appendChild(iframe)
   }
-  // Initialize Google Analytics.
-  if (navigator.onLine) {
-    var accounts = {{ site.google_analytics.accounts | jsonify }}
-    var commands = {{ site.google_analytics.commands | jsonify }}
-
-    commands[0][1] = accounts[location.hostname]
-
-    root[root.GoogleAnalyticsObject = '_ga'] = {
-      'l': Date.now(),
-      'q': commands
-    }
-    var script = document.createElement('script')
-    script.src = '{{ site.google_analytics.href }}'
-    head.appendChild(script)
-  }
   {% endif %}
 
   // Toggle offline status.


### PR DESCRIPTION
Would you be willing to remove this Google Analytics 'functionality' from this website? There are better alternatives if you *must* keep tabs on users' activity.

Some reputable alternatives can be seen here: https://switching.software/replace/google-analytics/