### PR TITLE
Update 4.17.15.html escapeRegExp [Fix issue #232]

### DIFF
--- a/docs/4.17.15.html
+++ b/docs/4.17.15.html
@@ -5354,7 +5354,7 @@ XSS vectors.</p>
 <div>
 <h3 id="escapeRegExp"><a href="#escapeRegExp" class="fa fa-link"></a><code>_.escapeRegExp([string=&apos;&apos;])</code></h3>
 <p><a href="https://github.com/lodash/lodash/blob/4.17.15/lodash.js#L14273">source</a> <a href="https://www.npmjs.com/package/lodash.escaperegexp">npm package</a></p>
-<p>Escapes the <code>RegExp</code> special characters &quot;^&quot;, &quot;$&quot;, &quot;&quot;, &quot;.&quot;, &quot;*&quot;, &quot;+&quot;,
+<p>Escapes the <code>RegExp</code> special characters &quot;^&quot;, &quot;$&quot;, &quot;&bsol;&quot;, &quot;.&quot;, &quot;*&quot;, &quot;+&quot;,
 &quot;?&quot;, &quot;(&quot;, &quot;)&quot;, &quot;[&quot;, &quot;]&quot;, &quot;{&quot;, &quot;}&quot;, and &quot;|&quot; in <code>string</code>.</p>
 <h4>Since</h4>
 <p>3.0.0</p>


### PR DESCRIPTION
Fix missing backslash entity for `_.escapeRegExp` doc description in v4.17.15.