### PR TITLE
corrected widths for social media division

### DIFF
--- a/assets/css/_home.scss
+++ b/assets/css/_home.scss
@@ -42,11 +42,11 @@ html.home {
     }
 
     .btn-gh {
-      width: 105px;
+      width: 115px;
     }
 
     .btn-twitter-follow {
-      width: 120px;
+      width: 136px;
     }
 
     .btn-twitter-share {


### PR DESCRIPTION
https://github.com/lodash/lodash.com/issues/269
There is a distortion in the social media division due to uneven widths and I have corrected the widths

Before

<img width="636" alt="image" src="https://user-images.githubusercontent.com/56450993/210864498-651e4828-9273-4d44-bb13-3efb3b43e8ab.png">

After

<img width="636" alt="image" src="https://user-images.githubusercontent.com/56450993/210864385-a005f5a9-3c09-4016-9199-4f75e84dd3d1.png">
