### PR TITLE
corrected width for social media app for all media width using rem property

### DIFF
--- a/assets/css/_home.scss
+++ b/assets/css/_home.scss
@@ -46,7 +46,7 @@ html.home {
     }
 
     .btn-twitter-follow {
-      width: 120px;
+      width: 20rem;
     }
 
     .btn-twitter-share {

--- a/assets/css/_home.scss
+++ b/assets/css/_home.scss
@@ -42,11 +42,11 @@ html.home {
     }
 
     .btn-gh {
-      width: 115px;
+      width: 10rem;
     }
 
     .btn-twitter-follow {
-      width: 20rem;
+      width: 16rem;
     }
 
     .btn-twitter-share {


### PR DESCRIPTION
 .btn-twitter-follow {
      width: 120px;
    }
is changed to
 .btn-twitter-follow {
      width: 16rem;
    }
and update (follow @bestie js) twitter button width issue and its compatible with all media width ,and use rem property that will work on all media width then pixel value to hardcore ,Thank You 
![1](https://user-images.githubusercontent.com/100468926/211158660-60078c48-41dd-4df9-9f4f-701b1fa76e6f.png)
![2](https://user-images.githubusercontent.com/100468926/211158667-b465afe7-66d9-42c1-aaa1-09136924e2e8.png)
