### PR TITLE
pref: improve the search performance

### DIFF
--- a/assets/css/_docs.scss
+++ b/assets/css/_docs.scss
@@ -134,7 +134,7 @@ html.docs {
   .doc-main {
     background-color: $foreground;
     display: flex;
-    flex: 1 1 auto;
+    flex: 1 1 100%;
     overflow: hidden;
     position: relative;
     width: 100%;


### PR DESCRIPTION
Related  issues #210 #212 
The input action in docs search box result in page reflow and then block js, ultimately leading to search lagging.
![perf](https://github.com/lodash/lodash.com/assets/40891772/aad25714-55b2-4855-8c5e-700b8a98b00d)
I'm not sure what directly caused it, but uncertain height of  `.doc-container` element maybe one significant indirect cause (I have already exclude factors such as React re-rendering, event handling, and search function consumption). 

I speculate `.doc-main` style `flex: 1 1 auto` causing this uncertain behavior. Changing it to `flex:1 1 100% | flex:1 1 100vh | flex:1 1 0 `  indeed effective for me. Additionally, Set the `.doc-container` element height to a fixed value also works.

The performance after modification:
![image](https://github.com/lodash/lodash.com/assets/40891772/1ddb4053-b8ce-4d1e-a965-d10c028000ab)

ps: I always browsing lodash.com website in desktop as a PWA application, so I used to think the issue was due to PWA performance.😂
